### PR TITLE
chore(deps): migrate to sypl v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,7 +39,8 @@ jobs:
         uses: actions/setup-go@v4.0.0
         with:
           # The Go version to download (if necessary) and use. Supports semver spec and ranges.
-          go-version: 1.21
+          # sypl v2 requires go >= 1.23, so go mod tidy raised the module's go directive to 1.23.
+          go-version: "1.23"
           cache: true
 
       - name: Setup golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/WreckingBallStudioLabs/pubsub
 
-go 1.21
+go 1.23
 
 require (
 	github.com/eapache/go-resiliency v1.6.0
@@ -12,7 +12,7 @@ require (
 	github.com/thalesfsp/configurer v1.3.22
 	github.com/thalesfsp/customerror v1.2.1
 	github.com/thalesfsp/status v1.0.17
-	github.com/thalesfsp/sypl v1.9.18
+	github.com/thalesfsp/sypl/v2 v2.0.0
 	github.com/thalesfsp/validation v0.0.3
 	go.elastic.co/apm v1.15.0
 )
@@ -30,7 +30,7 @@ require (
 	github.com/elastic/go-sysinfo v1.14.0 // indirect
 	github.com/elastic/go-windows v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/fatih/color v1.17.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -50,6 +50,7 @@ require (
 	github.com/prometheus/procfs v0.15.0 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
 	github.com/thalesfsp/randomness v0.0.9 // indirect
+	github.com/thalesfsp/sypl v1.9.18 // indirect
 	go.elastic.co/fastjson v1.3.0 // indirect
 	go.opentelemetry.io/otel v1.27.0 // indirect
 	go.opentelemetry.io/otel/metric v1.27.0 // indirect
@@ -59,7 +60,7 @@ require (
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
-	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/sys v0.27.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/tools v0.21.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUt
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
-github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/gabriel-vasile/mimetype v1.4.4 h1:QjV6pZ7/XZ7ryI2KuyeEDE8wnh7fHP9YnQy+R0LnH8I=
 github.com/gabriel-vasile/mimetype v1.4.4/go.mod h1:JwLei5XPtWdGiMFB5Pjle1oEeoSeEuJfJE+TtfvdB/s=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -121,6 +121,8 @@ github.com/thalesfsp/status v1.0.17 h1:9uo6QLBEk7n7AoUf3zD7DDGfj0JwRP+DI+ECF5yMu
 github.com/thalesfsp/status v1.0.17/go.mod h1:ZwlaaU4tPETPq/wf3bsS/sVqSQpMUPMK7iTqkSSJqVY=
 github.com/thalesfsp/sypl v1.9.18 h1:TWR7zWRLA9kJECsvNghdWtGPll7+BrHlaV/08xeV8dg=
 github.com/thalesfsp/sypl v1.9.18/go.mod h1:XVdPSJi9P0QptQnWaUUjZ67GpUBI91Q8AQzbUmy9zj4=
+github.com/thalesfsp/sypl/v2 v2.0.0 h1:sG8R5DPKpsbq0pF+jSlEy1XNYIrhTUbfwA1duLmq5/8=
+github.com/thalesfsp/sypl/v2 v2.0.0/go.mod h1:RCM1KBOet35pLWc6VPixSPPa5neyxaGJHGeRT5CEczY=
 github.com/thalesfsp/validation v0.0.3 h1:iXWXZLALIGUKJSxAeDt40kxUyzjeHeHc86f9fP9vin4=
 github.com/thalesfsp/validation v0.0.3/go.mod h1:0jwfQpbuzVJgVSPoiDJ7KCT76CLdMq4R++InC353SZ8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -175,8 +177,8 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211102192858-4dd72447c267/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
-golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/customapm/error.go
+++ b/internal/customapm/error.go
@@ -6,9 +6,9 @@ import (
 	"expvar"
 
 	"github.com/WreckingBallStudioLabs/pubsub/internal/logging"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/fields"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/fields"
+	"github.com/thalesfsp/sypl/v2/level"
 	"go.elastic.co/apm"
 )
 

--- a/internal/customapm/logger.go
+++ b/internal/customapm/logger.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/WreckingBallStudioLabs/pubsub/internal/logging"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/level"
 	"github.com/thalesfsp/validation"
 )
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"sync"
 
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/fields"
-	"github.com/thalesfsp/sypl/level"
-	"github.com/thalesfsp/sypl/processor"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/fields"
+	"github.com/thalesfsp/sypl/v2/level"
+	"github.com/thalesfsp/sypl/v2/processor"
 	"go.elastic.co/apm"
 )
 

--- a/nats/nats.go
+++ b/nats/nats.go
@@ -16,9 +16,9 @@ import (
 	"github.com/thalesfsp/concurrentloop"
 	"github.com/thalesfsp/customerror"
 	"github.com/thalesfsp/status"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/fields"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/fields"
+	"github.com/thalesfsp/sypl/v2/level"
 	"github.com/thalesfsp/validation"
 )
 

--- a/pubsub/interface.go
+++ b/pubsub/interface.go
@@ -7,7 +7,7 @@ import (
 	"github.com/WreckingBallStudioLabs/pubsub/message"
 	"github.com/WreckingBallStudioLabs/pubsub/subscription"
 	"github.com/thalesfsp/concurrentloop"
-	"github.com/thalesfsp/sypl"
+	"github.com/thalesfsp/sypl/v2"
 )
 
 //////

--- a/pubsub/mock.go
+++ b/pubsub/mock.go
@@ -7,7 +7,7 @@ import (
 	"github.com/WreckingBallStudioLabs/pubsub/message"
 	"github.com/WreckingBallStudioLabs/pubsub/subscription"
 	"github.com/thalesfsp/concurrentloop"
-	"github.com/thalesfsp/sypl"
+	"github.com/thalesfsp/sypl/v2"
 )
 
 //////

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -9,8 +9,8 @@ import (
 	"github.com/WreckingBallStudioLabs/pubsub/internal/logging"
 	"github.com/WreckingBallStudioLabs/pubsub/internal/metrics"
 	"github.com/thalesfsp/status"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/level"
 	"github.com/thalesfsp/validation"
 )
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -17,9 +17,9 @@ import (
 	"github.com/thalesfsp/concurrentloop"
 	"github.com/thalesfsp/customerror"
 	"github.com/thalesfsp/status"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/fields"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/fields"
+	"github.com/thalesfsp/sypl/v2/level"
 	"github.com/thalesfsp/validation"
 )
 


### PR DESCRIPTION
## What

Migrates `pubsub` from `sypl` v1 (v1.9.18) to `sypl` v2 (v2.0.0).

sypl v2 ships three breaking changes (module path `/v2`, ElasticSearch isolated into a separate `es/` submodule, and a `Warn`/`Info` level reorder). This repo is on the trivial path for all three:

- **No ElasticSearch** outputs are used, so the ES submodule split is a non-event.
- **No removed v1 APIs** (`SetName`, `GetProcessor`, `SetContent`, `SetLevel`, `AnyMaxLevel`, `SetBuiltinLogger`, `FromInt`) are called.
- **Only `level.Error` and `level.Debug`** are used — both unaffected by the `Warn`/`Info` numeric swap.

So the change is a purely mechanical import-path rewrite plus a `go.mod`/`go.sum` update.

## Changes

- All `github.com/thalesfsp/sypl/...` imports rewritten to `github.com/thalesfsp/sypl/v2/...` (8 files, import lines only).
- `go.mod`: direct require is now `github.com/thalesfsp/sypl/v2 v2.0.0`; v1 remains only as a transitive indirect dep (pulled in by `concurrentloop`). `go mod tidy` bumped the `go` directive to `1.23` (required by sypl v2's own `go.mod`).

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `make test` (full `-race` suite) — pass ("Test OK")